### PR TITLE
[hht] Add WavetableSynth implementation based on Shan et al.

### DIFF
--- a/acid_ddsp/synth_modules.py
+++ b/acid_ddsp/synth_modules.py
@@ -482,7 +482,7 @@ class WavetableOscShan(WavetableOsc):
 
         """
         bs, n_wavetable, wt_len = wavetable.shape
-        arg = SquareSawVCOLite.calc_osc_arg(sr, f0_hz, n_samples, phase)
+        arg = SquareSawVCOLite.calc_osc_arg(sr, freq, n_samples, phase)
         arg = arg % (2 * tr.pi)
         index = arg / (2 * tr.pi) * wt_len 
 

--- a/acid_ddsp/synths.py
+++ b/acid_ddsp/synths.py
@@ -610,6 +610,18 @@ class WavetableSynthShan(WavetableSynth):
             wt=wt,
             is_trainable=is_trainable,
         )
+    
+    def additive_synthesis(
+        self,
+        n_samples: int,
+        f0_hz: T,
+        phase: T,
+        temp_params: Dict[str, T],
+        global_params: Dict[str, T],
+    ) -> (T, Dict[str, T]):
+        attention_matrix = temp_params.get("attention_matrix")
+        dry_audio = self.osc(f0_hz, attention_matrix, n_samples=n_samples, phase=phase)
+        return dry_audio, {}
 
 
 # if __name__ == "__main__":


### PR DESCRIPTION
Added WavetableSynth based on the Differentiable Wavetable Synth paper.
Implementation is slightly different from in [diff-wave-synth](https://github.com/gudgud96/diff-wave-synth/blob/master/wavetable_synth.py) as I used batch implementation here, also I aligned the wavetable input to the same dimension as the original Wavetable class which is `(batch_size, n_wavetable, wavetable_len,)`. 