### PR TITLE
[hht] Adapt DDSP harmonic + noise module into ComposableSynth framework

### DIFF
--- a/acid_ddsp/synth_modules.py
+++ b/acid_ddsp/synth_modules.py
@@ -517,7 +517,7 @@ class FourierWavetableOsc(WavetableOsc):
 class DDSPHarmonicOsc(SynthModule):
     """
     A harmonic oscillator from DDSP, largely following:
-    https://github.com/acids-ircam/ddsp_pytorch/blob/9db246f48dba66e9b2133691d7abf4af6ede0279/ddsp/model.py#L88
+    https://github.com/acids-ircam/ddsp_pytorch/blob/master/ddsp/core.py#L135
     """
     forward_param_names = [
         "f0_hz",

--- a/acid_ddsp/util.py
+++ b/acid_ddsp/util.py
@@ -170,3 +170,10 @@ def load_class_from_yaml(config_path: str) -> Any:
     cls = getattr(module, class_name)
     cls_instantiated = cls(**config["init_args"])
     return cls_instantiated
+
+
+def scale_function(x: T, eps: float = 1e-7) -> T:
+    """
+    Scale function as per DDSP paper Section B.5, equation 5
+    """
+    return 2 * (tr.sigmoid(x) ** tr.log(tr.tensor(10).to(x.device))) + eps

--- a/configs/synthetic_2/ddsp_osc__harmonic.yml
+++ b/configs/synthetic_2/ddsp_osc__harmonic.yml
@@ -1,0 +1,4 @@
+class_path: acid_ddsp.synth_modules.DDSPHarmonicOsc
+init_args:
+  sr: 48000
+  n_harmonics: 100    # default value from original DDSP

--- a/configs/synthetic_2/ddsp_osc__noise.yml
+++ b/configs/synthetic_2/ddsp_osc__noise.yml
@@ -1,0 +1,4 @@
+class_path: acid_ddsp.synth_modules.DDSPNoiseModule
+init_args:
+  sr: 48000
+  n_bands: 65     # default value from original DDSP

--- a/configs/synthetic_2/spectral_2dcnn_dd50__ase__ddsp.yml
+++ b/configs/synthetic_2/spectral_2dcnn_dd50__ase__ddsp.yml
@@ -14,10 +14,10 @@ init_args:
       is_spline: true
       n_segments: 24
       degree: 3
-      is_bounded: true
-      use_alpha_noise: true
+      is_bounded: false
+      use_alpha_noise: false
       use_alpha_linear: true
-      adapt_dim: 100
+      adapt_dim: 101
       adapt_act: none
       adapt_use_separate: true
     sub_lfo:

--- a/configs/synthetic_2/spectral_2dcnn_dd50__ase__ddsp.yml
+++ b/configs/synthetic_2/spectral_2dcnn_dd50__ase__ddsp.yml
@@ -1,0 +1,49 @@
+class_path: models.Spectral2DCNN
+init_args:
+  fe: log_mel_spec_dd50.yml
+  in_ch: 3
+  kernel_size: [5, 7]
+  out_channels: [64, 64, 64, 64, 64, 64]
+  temp_dilations: [1, 4, 16, 32, 64, 128]
+  pool_size: [2, 1]
+  use_ln: true
+  temp_params:
+    add_lfo:
+      dim: 1
+      act: none
+      is_spline: true
+      n_segments: 24
+      degree: 3
+      is_bounded: true
+      use_alpha_noise: true
+      use_alpha_linear: true
+      adapt_dim: 100
+      adapt_act: none
+      adapt_use_separate: true
+    sub_lfo:
+      dim: 1
+      act: none
+      is_spline: true
+      n_segments: 24
+      degree: 3
+      is_bounded: false
+      use_alpha_noise: false
+      use_alpha_linear: true
+      adapt_dim: 65
+      adapt_act: none
+      adapt_use_separate: true
+    env:
+      dim: 1
+      act: none
+      is_spline: true
+      n_segments: 24
+      degree: 3
+      is_bounded: true
+      use_alpha_noise: false
+      use_alpha_linear: true
+      adapt_dim: 0
+  dropout: 0.0
+  n_frames: 1501
+  cnn_act: prelu
+  fc_act: prelu
+  noise_std: 0.33

--- a/configs/synthetic_2/synth__ase__ddsp.yml
+++ b/configs/synthetic_2/synth__ase__ddsp.yml
@@ -1,0 +1,7 @@
+class_path: synths.ComposableSynth
+init_args:
+  ac: audio_config.yml
+  add_synth_module: ddsp_osc__harmonic.yml
+  sub_synth_module: ddsp_osc__noise.yml
+  add_lfo_name: add_lfo_adapted
+  sub_lfo_name: sub_lfo_adapted

--- a/configs/synthetic_2/train__ase__ddsp.yml
+++ b/configs/synthetic_2/train__ase__ddsp.yml
@@ -43,7 +43,7 @@ model:
   init_args:
     ac: audio_config.yml
     spectral_visualizer: log_mel_spec.yml
-    synth: synth__ase__ddsp.yml
+    synth: synth__ase.yml
     temp_param_names:
       - add_lfo
       - sub_lfo
@@ -52,8 +52,7 @@ model:
       - add_lfo
       - sub_lfo
       - env
-    # model: spectral_2dcnn_dd50__ase__lfo.yml
-    model: spectral_2dcnn_dd50__ase__sm.yml
+    model: spectral_2dcnn_dd50__ase__ddsp.yml
     temp_param_names_hat:
       - add_lfo
       - sub_lfo

--- a/configs/synthetic_2/train__ase__ddsp.yml
+++ b/configs/synthetic_2/train__ase__ddsp.yml
@@ -1,0 +1,78 @@
+custom:
+  project_name: acid_ddsp_2
+  model_name: mss__s24d3D_nn__lfo
+  dataset_name: lfo__ase__fm_fold
+  cpu_batch_size: 5
+  use_wandb_cpu: false
+#  use_wandb_gpu: true
+  use_wandb_gpu: false
+
+trainer:
+  accelerator: gpu
+  benchmark: false
+  devices: [0]
+  max_epochs: 30
+  num_sanity_val_steps: 1
+  gradient_clip_val: 0.5
+
+data:
+  class_path: acid_ddsp.data_modules.SeedDataModule
+  init_args:
+    batch_size: 32
+    ac: audio_config.yml
+    n_seeds: 1024
+    mod_sig_gens:
+      - class_path: acid_ddsp.modulations.ModSignalGenRandomBezier1D
+        init_args:
+          min_n_seg: 1
+          max_n_seg: 8
+          min_degree: 1
+          max_degree: 3
+          min_seg_interval_frac: 0.5
+    global_param_names:
+      - q
+    temp_param_names:
+      - add_lfo
+      - sub_lfo
+      - env
+    n_frames: 1501
+    num_workers: 4
+
+model:
+  class_path: acid_ddsp.lightning.AcidDDSPLightingModule
+  init_args:
+    ac: audio_config.yml
+    spectral_visualizer: log_mel_spec.yml
+    synth: synth__ase__ddsp.yml
+    temp_param_names:
+      - add_lfo
+      - sub_lfo
+      - env
+    interp_temp_param_names:
+      - add_lfo
+      - sub_lfo
+      - env
+    # model: spectral_2dcnn_dd50__ase__lfo.yml
+    model: spectral_2dcnn_dd50__ase__sm.yml
+    temp_param_names_hat:
+      - add_lfo
+      - sub_lfo
+      - env
+    interp_temp_param_names_hat:
+      - add_lfo
+      - sub_lfo
+      - env
+    synth_hat: synth__ase__ddsp.yml
+
+    loss_func: auraloss.freq.MultiResolutionSTFTLoss
+    use_p_loss: false
+
+    model_opt: ../opt/sf_adam_w__lr_5e-3.yml
+
+    fad_model_names:
+      - clap-2023
+      - encodec-emb-48k
+      - panns-cnn14-32k
+      - panns-wavegram-logmel
+
+    run_name: mss__s24d3D_nn__lfo__lfo__ase__fm_fold

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -35,6 +35,10 @@ if __name__ == "__main__":
     # config_name = "synthetic_2/train.yml"
 
     # config_name = "synthetic_2/train__ase__lfo.yml"
+<<<<<<< HEAD
+=======
+    config_name = "synthetic_2/train__ase__ddsp.yml"
+>>>>>>> 608ab58 ([cm] DDSP training working)
     # config_name = "synthetic_2/train__ase__lfo_frame.yml"
     config_name = "synthetic_2/train__ase__lfo_frame_8_hz.yml"
 
@@ -103,7 +107,7 @@ if __name__ == "__main__":
             # wt_module_hat = WavetableOsc(sr=sr, wt=basic_shapes_wt, is_trainable=True)
             # synth_hat.register_module("add_synth_module", wt_module_hat)
 
-            if not synth_hat.add_synth_module.is_trainable:
+            if isinstance(synth_hat.add_synth_module, WavetableOsc) and  not synth_hat.add_synth_module.is_trainable:
                 wt_module_hat = WavetableOsc(sr=sr, wt=wt, is_trainable=False)
                 synth_hat.register_module("add_synth_module", wt_module_hat)
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -35,10 +35,6 @@ if __name__ == "__main__":
     # config_name = "synthetic_2/train.yml"
 
     # config_name = "synthetic_2/train__ase__lfo.yml"
-<<<<<<< HEAD
-=======
-    config_name = "synthetic_2/train__ase__ddsp.yml"
->>>>>>> 608ab58 ([cm] DDSP training working)
     # config_name = "synthetic_2/train__ase__lfo_frame.yml"
     config_name = "synthetic_2/train__ase__lfo_frame_8_hz.yml"
 


### PR DESCRIPTION
Revamp DDSP logic to fit into ComposableSynth framework:
- The harmonic part takes `"f0_hz", "harmonic_amplitudes", "n_samples", "phase"`
- We treat the noise module as the "subtractive" part of other synth, which takes in the output of the harmonic oscillator and adds filtered noise